### PR TITLE
Fix redirection when navigating to signup page after logged in

### DIFF
--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -160,7 +160,7 @@ export default function SignUpPage() {
   useEffect(() => {
     getSession().then((session) => {
       if (session) {
-        router.replace("/");
+        router.replace("/contacts");
       } else {
         setIsLoading(false);
       }


### PR DESCRIPTION
When navigating to signup page after logging in, you are redirected to the home page (contacts list page)